### PR TITLE
Move README to markdown; enable out-of-tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ distclean-local:
 EXTRA_DIST = config.rpath \
   po/POTFILES.skip \
   qof.pc.in \
-  qofsql.symbols
+  qofsql.symbols \
+  README.md
 
 ACLOCAL_AMFLAGS = -I m4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-                QOF - Query Object Framework
-                ----------------------------
+QOF - Query Object Framework
+============================
 
 Please see the NEWS file and the ChangeLog for detailed
 information on changes since 0.6.0.
+
+Building
+--------
+See the [README.vcs](README.vcs) for instructions on how to build this.
 
 pkg-config support prior to libqof2
 -----------------------------------
@@ -17,5 +21,3 @@ The QOF documentation is entirely embedded in the source code. You
 can build an html version of the documentation by installing the
 'doxygen' package, and then 'cd doc; make doc'.  Skim the doc/README
 file for more info.
-
-------------------------- END OF DOCUMENT -------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,10 @@ VERSION=AC_PACKAGE_VERSION
 AC_SUBST(VERSION)
 PACKAGE=AC_PACKAGE_NAME
 AC_SUBST(PACKAGE)
-AM_INIT_AUTOMAKE()
+
+dnl "foreign" allows README.md instead of README
+dnl subdir-objects simplified out-of-tree builds.
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 AC_PROG_LIBTOOL
 AC_CONFIG_HEADERS([config.h])

--- a/lib/libsql/Makefile.am
+++ b/lib/libsql/Makefile.am
@@ -36,10 +36,10 @@ AM_CFLAGS = -g     \
 #	-I$(includedir) 
 
 parser.c: parser.y
-	$(YACC) -v -d -o parser.c -p sql parser.y
+	$(YACC) -v -d -o parser.c -p sql $(top_srcdir)/lib/libsql/parser.y
 
 lexer.c: lexer.l parser.c
-	$(LEX) -olexer.c -Psql lexer.l
+	$(LEX) -olexer.c -Psql $(top_srcdir)/lib/libsql/lexer.l
 
 sql_parse_test_SOURCES=sql_parse_test.c
 # sql_parse_test_LDFLAGS = $(LIBGDA_LIBS)
@@ -47,4 +47,3 @@ sql_parse_test_DEPENDENCIES = ./libqofsql.la
 sql_parse_test_LDADD = ./libqofsql.la ${GLIB_LIBS}
 
 tests: sql_parse_test
-


### PR DESCRIPTION
This moves `README` to `README.md`

It also enables out-of0-tree builds, e.g.
```
    mkdir build; cd build
    ../configure
    make
```
